### PR TITLE
Optimizations in `labor_demand` Module

### DIFF
--- a/labor_demand.m
+++ b/labor_demand.m
@@ -19,9 +19,10 @@ function [LSH, LD_HH, LD_LH, LD_IH, LSL, LD_HL, LD_LL, LD_IL] = labor_demand(wH,
     profitH = p.avecH.*kappa.*(   ( ( ((IzH.^gamma).*b + (LzH.^gamma)).*a).^(rho/gamma) + HzH.^rho ).^(alpha/rho)) - (HzH.*wH + LzH.*wL + IzH.*wI);
     wvecH = wH * ones(length(profitH), 1);
     LSH = sum(wvecH > profitH);
-    LD_HH = (profitH > wH)' * HzH;
-    LD_LH = (profitH > wH)' * LzH;
-    LD_IH = (profitH > wH)' * IzH;
+
+    LD_HH = sum(HzH(profitH > wH));
+    LD_LH = sum(LzH(profitH > wH));
+    LD_IH = sum(IzH(profitH > wH));
 
     % Low skill
     IzL =  ((p.avecL.* (alpha * J * G * a * b))./(wI)).^(1/(1-alpha));
@@ -30,10 +31,9 @@ function [LSH, LD_HH, LD_LH, LD_IH, LSL, LD_HL, LD_LL, LD_IL] = labor_demand(wH,
     profitL = p.avecL.*(   ( ( ((IzL.^gamma).*b + (LzL.^gamma)).*a).^(rho/gamma) + HzL.^rho ).^(alpha/rho)) - (HzL.*wH + LzL.*wL + IzL.*wI);
     wvecL = wL * ones(length(profitL), 1);
     LSL = sum(wvecL > profitL);
-    LD_HL = (profitL > wL)' * HzL;
-    LD_LL = (profitL > wL)' * LzL;
-    LD_IL = (profitL > wL)' * IzL;
-    
-end    
-    
-   
+
+    LD_HL = sum(HzL(profitL > wL));
+    LD_LL = sum(LzL(profitL > wL));
+    LD_IL = sum(IzL(profitL > wL));
+
+end

--- a/labor_demand.m
+++ b/labor_demand.m
@@ -8,11 +8,14 @@ function [LSH, LD_HH, LD_LH, LD_IH, LSL, LD_HL, LD_LL, LD_IL] = labor_demand(wH,
     
     G = (b+ (wI/(wL*b))^((gamma)/(1-gamma)) )^((rho-gamma)/gamma);
     J = ( (a*G^(rho/(rho - gamma))) + (wI/(G*a*b*wH))^(rho/(1-rho))  )^((alpha-rho)/(rho));
-    
+
+    commonExp1 = (wI/(wL*b))^(1/(1-gamma));
+    commonExp2 = ( (wI/(G*a*b*wH)) )^(1/(1-rho));
+
     % High skill
     IzH =  ((p.avecH.* (kappa*alpha * J * G * a * b))./(wI)).^(1/(1-alpha));
-    LzH =  IzH .*( (wI/(wL*b))^(1/(1-gamma)) );
-    HzH =  IzH .*( (wI/(G*a*b*wH)) )^(1/(1-rho));
+    LzH =  IzH .*commonExp1;
+    HzH =  IzH .*commonExp2;
     profitH = p.avecH.*kappa.*(   ( ( ((IzH.^gamma).*b + (LzH.^gamma)).*a).^(rho/gamma) + HzH.^rho ).^(alpha/rho)) - (HzH.*wH + LzH.*wL + IzH.*wI);
     wvecH = wH * ones(length(profitH), 1);
     LSH = sum(wvecH > profitH);
@@ -22,8 +25,8 @@ function [LSH, LD_HH, LD_LH, LD_IH, LSL, LD_HL, LD_LL, LD_IL] = labor_demand(wH,
 
     % Low skill
     IzL =  ((p.avecL.* (alpha * J * G * a * b))./(wI)).^(1/(1-alpha));
-    LzL =  IzL .*( (wI/(wL*b))^(1/(1-gamma)) );
-    HzL =  IzL .*( (wI/(G*a*b*wH)) )^(1/(1-rho));
+    LzL =  IzL .*commonExp1;
+    HzL =  IzL .*commonExp2;
     profitL = p.avecL.*(   ( ( ((IzL.^gamma).*b + (LzL.^gamma)).*a).^(rho/gamma) + HzL.^rho ).^(alpha/rho)) - (HzL.*wH + LzL.*wL + IzL.*wI);
     wvecL = wL * ones(length(profitL), 1);
     LSL = sum(wvecL > profitL);

--- a/labor_demand.m
+++ b/labor_demand.m
@@ -17,8 +17,8 @@ function [LSH, LD_HH, LD_LH, LD_IH, LSL, LD_HL, LD_LL, LD_IL] = labor_demand(wH,
     LzH =  IzH .*commonExp1;
     HzH =  IzH .*commonExp2;
     profitH = p.avecH.*kappa.*(   ( ( ((IzH.^gamma).*b + (LzH.^gamma)).*a).^(rho/gamma) + HzH.^rho ).^(alpha/rho)) - (HzH.*wH + LzH.*wL + IzH.*wI);
-    wvecH = wH * ones(length(profitH), 1);
-    LSH = sum(wvecH > profitH);
+
+    LSH = sum(wH > profitH);
 
     LD_HH = sum(HzH(profitH > wH));
     LD_LH = sum(LzH(profitH > wH));
@@ -29,8 +29,8 @@ function [LSH, LD_HH, LD_LH, LD_IH, LSL, LD_HL, LD_LL, LD_IL] = labor_demand(wH,
     LzL =  IzL .*commonExp1;
     HzL =  IzL .*commonExp2;
     profitL = p.avecL.*(   ( ( ((IzL.^gamma).*b + (LzL.^gamma)).*a).^(rho/gamma) + HzL.^rho ).^(alpha/rho)) - (HzL.*wH + LzL.*wL + IzL.*wI);
-    wvecL = wL * ones(length(profitL), 1);
-    LSL = sum(wvecL > profitL);
+
+    LSL = sum(wL > profitL);
 
     LD_HL = sum(HzL(profitL > wL));
     LD_LL = sum(LzL(profitL > wL));


### PR DESCRIPTION
## Description

Introduced several optimizations in the `labor_demand` module. These changes aim to improve code efficiency and readability without altering the underlying logic or output.

## Changes

- *Centralized Common Expressions*: Previously, certain expressions were repeated in multiple places. We've now centralized these expressions into single statements. This change reduces redundancy and eases future modifications, as updates to these expressions will now only need to be made in one location.
- *Optimized Conditional Sum Using Scalars*:
```matlab
- wvecH = wH * ones(length(profitH), 1);
- LSH = sum(wvecH > profitH);
+ LSH = sum(wH > profitH);
```
Justification: The original implementation created unnecessary arrays `wvec*` by replicating the scalars `w*`. This was memory-inefficient, especially for large arrays. The new code directly compares the scalars with each element of `profit*`, thus eliminating the need for extra memory allocation and speeding up the computation.

- *Introduced Sum with Logical Indexing*:
```matlab
- LD_HL = (profitL > wL)' * HzL;
+ LD_HL = sum(HzL(profitL > wL));
```
 Justification: The original code used a matrix multiplication approach to filter and sum elements of `*z*` where `profit*` exceeds `w*`. The new implementation leverages MATLAB's logical indexing, which is more direct and readable. This approach is also typically faster, as it avoids the overhead of transposing and multiplying matrices.

## Conclusion

These optimizations are expected to enhance the performance of the `labor_demand` module by reducing memory usage and improving execution time. The changes also contribute to more readable and maintainable code.

Profiling their effect showed a significant speedup during execution of the function.